### PR TITLE
Switch to using mm:u, add NVENC and NVJPG

### DIFF
--- a/source/Utils.hpp
+++ b/source/Utils.hpp
@@ -30,7 +30,9 @@ std::string filename = "";
 std::string filepath = "";
 
 //Misc2
-NvChannel nvdecChannel;
+MmuRequest nvdecRequest;
+MmuRequest nvencRequest;
+MmuRequest nvjpgRequest;
 
 //Mini mode
 char Variables[768];
@@ -47,6 +49,8 @@ Result pmdmntCheck = 1;
 Result psmCheck = 1;
 Result audsnoopCheck = 1;
 Result nvdecCheck = 1;
+Result nvencCheck = 1;
+Result nvjpgCheck = 1;
 Result nifmCheck = 1;
 
 //Wi-Fi
@@ -58,9 +62,13 @@ Result Nifm_profile_rc = -1;
 NifmNetworkProfileData_new Nifm_profile = {0};
 char Nifm_pass[96];
 
-//NVDEC
+//Multimedia engines
 uint32_t NVDEC_Hz = 0;
+uint32_t NVENC_Hz = 0;
+uint32_t NVJPG_Hz = 0;
 char NVDEC_Hz_c[32];
+char NVENC_Hz_c[32];
+char NVJPG_Hz_c[32];
 
 //DSP
 uint32_t DSP_Load_u = -1;
@@ -400,8 +408,10 @@ void Misc2(void*) {
 		//DSP
 		if (R_SUCCEEDED(audsnoopCheck)) audsnoopGetDspUsage(&DSP_Load_u);
 
-		//NVDEC clock rate
-		if (R_SUCCEEDED(nvdecCheck)) getNvChannelClockRate(&nvdecChannel, 0x75, &NVDEC_Hz);
+		//Multimedia clock rates
+		if (R_SUCCEEDED(nvdecCheck)) mmuRequestGet(&nvdecRequest, &NVDEC_Hz);
+		if (R_SUCCEEDED(nvencCheck)) mmuRequestGet(&nvencRequest, &NVENC_Hz);
+		if (R_SUCCEEDED(nvjpgCheck)) mmuRequestGet(&nvjpgRequest, &NVJPG_Hz);
 
 		if (R_SUCCEEDED(nifmCheck)) {
 			u32 dummy = 0;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -987,6 +987,8 @@ public:
 				else fanCheck = fanOpenController(&g_ICon, 1);
 			}
 
+			if (R_SUCCEEDED(nvInitialize())) nvCheck = nvOpen(&fd, "/dev/nvhost-ctrl-gpu");
+
 			if (R_SUCCEEDED(mmuInitialize())) {
 				nvdecCheck = mmuRequestInitialize(&nvdecRequest, MmuModuleId(5), 8, false);
 				nvencCheck = mmuRequestInitialize(&nvencRequest, MmuModuleId(6), 8, false);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -664,28 +664,34 @@ public:
 				renderer->drawString(DSP_Load_c, false, 20, 120, 20, renderer->a(0xFFFF));
 			}
 
-			//NVDEC
-			if (R_SUCCEEDED(nvdecCheck)) {
-				renderer->drawString(NVDEC_Hz_c, false, 20, 165, 20, renderer->a(0xFFFF));
+			//Multimedia engines
+			if (R_SUCCEEDED(nvdecCheck | nvencCheck | nvjpgCheck)) {
+				renderer->drawString("Multimedia clock rates:", false, 20, 165, 20, renderer->a(0xFFFF));
+				if (R_SUCCEEDED(nvdecCheck))
+					renderer->drawString(NVDEC_Hz_c, false, 35, 185, 15, renderer->a(0xFFFF));
+				if (R_SUCCEEDED(nvencCheck))
+					renderer->drawString(NVENC_Hz_c, false, 35, 200, 15, renderer->a(0xFFFF));
+				if (R_SUCCEEDED(nvjpgCheck))
+					renderer->drawString(NVJPG_Hz_c, false, 35, 215, 15, renderer->a(0xFFFF));
 			}
 
 			if (R_SUCCEEDED(nifmCheck)) {
-				renderer->drawString("Network", false, 20, 210, 20, renderer->a(0xFFFF));
+				renderer->drawString("Network", false, 20, 255, 20, renderer->a(0xFFFF));
 				if (!Nifm_internet_rc) {
 					if (NifmConnectionType == NifmInternetConnectionType_WiFi) {
-						renderer->drawString("Type: Wi-Fi", false, 20, 235, 18, renderer->a(0xFFFF));
+						renderer->drawString("Type: Wi-Fi", false, 20, 280, 18, renderer->a(0xFFFF));
 						if (!Nifm_profile_rc) {
 							if (Nifm_showpass)
-								renderer->drawString(Nifm_pass, false, 20, 260, 15, renderer->a(0xFFFF));
+								renderer->drawString(Nifm_pass, false, 20, 305, 15, renderer->a(0xFFFF));
 							else
-								renderer->drawString("Press Y to show password", false, 20, 260, 15, renderer->a(0xFFFF));
+								renderer->drawString("Press Y to show password", false, 20, 305, 15, renderer->a(0xFFFF));
 						}
 					}
 					else if (NifmConnectionType == NifmInternetConnectionType_Ethernet)
-						renderer->drawString("Type: Ethernet", false, 20, 235, 18, renderer->a(0xFFFF));
+						renderer->drawString("Type: Ethernet", false, 20, 280, 18, renderer->a(0xFFFF));
 				}
 				else
-					renderer->drawString("Type: Not connected", false, 20, 235, 18, renderer->a(0xFFFF));
+					renderer->drawString("Type: Not connected", false, 20, 280, 18, renderer->a(0xFFFF));
 		}
 
 		});
@@ -698,7 +704,9 @@ public:
 	virtual void update() override {
 
 		snprintf(DSP_Load_c, sizeof DSP_Load_c, "DSP usage: %u%%", DSP_Load_u);
-		snprintf(NVDEC_Hz_c, sizeof NVDEC_Hz_c, "NVDEC clock rate: %.1f MHz", (float)NVDEC_Hz / 1000);
+		snprintf(NVDEC_Hz_c, sizeof NVDEC_Hz_c, "NVDEC: %.1f MHz", (float)NVDEC_Hz / 1000000);
+		snprintf(NVENC_Hz_c, sizeof NVENC_Hz_c, "NVENC: %.1f MHz", (float)NVENC_Hz / 1000000);
+		snprintf(NVJPG_Hz_c, sizeof NVJPG_Hz_c, "NVJPG: %.1f MHz", (float)NVJPG_Hz / 1000000);
 		char pass_temp1[25] = "";
 		char pass_temp2[25] = "";
 		char pass_temp3[17] = "";
@@ -979,9 +987,12 @@ public:
 				else fanCheck = fanOpenController(&g_ICon, 1);
 			}
 
-			if (R_SUCCEEDED(nvInitialize())) nvCheck = nvOpen(&fd, "/dev/nvhost-ctrl-gpu");
-			if (R_SUCCEEDED(nvMapInit())) nvdecCheck = nvChannelCreate(&nvdecChannel, "/dev/nvhost-nvdec");
-			
+			if (R_SUCCEEDED(mmuInitialize())) {
+				nvdecCheck = mmuRequestInitialize(&nvdecRequest, MmuModuleId(5), 8, false);
+				nvencCheck = mmuRequestInitialize(&nvencRequest, MmuModuleId(6), 8, false);
+				nvjpgCheck = mmuRequestInitialize(&nvjpgRequest, MmuModuleId(7), 8, false);
+			}
+
 			if (R_SUCCEEDED(audsnoopInitialize())) audsnoopCheck = audsnoopEnableDspUsageMeasurement();
 
 			psmCheck = psmInitialize();
@@ -1009,7 +1020,10 @@ public:
 		tcExit();
 		fanControllerClose(&g_ICon);
 		fanExit();
-		nvChannelClose(&nvdecChannel);
+		mmuRequestFinalize(&nvdecRequest);
+		mmuRequestFinalize(&nvencRequest);
+		mmuRequestFinalize(&nvjpgRequest);
+		mmuExit();
 		nvMapExit();
 		nvClose(fd);
 		nvExit();


### PR DESCRIPTION
Supersedes https://github.com/masagrator/Status-Monitor-Overlay/pull/26.
I verified with my own reverse engineering that the MmuModuleIds on libnx are switched for NVDEC and NVENC. 