### PR TITLE
Switch from "ts" to i2c for reading PCB/SoC temperatures

### DIFF
--- a/include/i2c.h
+++ b/include/i2c.h
@@ -1,14 +1,6 @@
-/*
-Functions taken from Switch-OC-Suite source code made by KazushiMe
-Original repository link (Deleted, last checked 15.04.2023): https://github.com/KazushiMe/Switch-OC-Suite
-*/
+#pragma once
 
-#include "max17050.h"
-
-constexpr float max17050SenseResistor = MAX17050_BOARD_SNS_RESISTOR_UOHM / 1000; // in uOhm
-constexpr float max17050CGain = 1.99993;
-
-Result I2cReadRegHandler(u8 reg, I2cDevice dev, u16 *out)
+Result I2cReadRegHandler16(u8 reg, I2cDevice dev, u16 *out)
 {
 	struct readReg {
         u8 send;
@@ -46,16 +38,40 @@ Result I2cReadRegHandler(u8 reg, I2cDevice dev, u16 *out)
 	return 0;
 }
 
-Result Max17050ReadReg(u8 reg, u16 *out)
+Result I2cReadRegHandler8(u8 reg, I2cDevice dev, u8 *out)
 {
-	u16 data = 0;
-	Result res = I2cReadRegHandler(reg, I2cDevice_Max17050, &data);
+	struct readReg {
+        u8 send;
+        u8 sendLength;
+        u8 sendData;
+        u8 receive;
+        u8 receiveLength;
+    };
 
-	if (R_FAILED(res))
+	I2cSession _session;
+
+	Result res = i2cOpenSession(&_session, dev);
+	if (res)
+		return res;
+
+	u8 val;
+
+    struct readReg readRegister = {
+        .send = 0 | (I2cTransactionOption_Start << 6),
+        .sendLength = sizeof(reg),
+        .sendData = reg,
+        .receive = 1 | (I2cTransactionOption_All << 6),
+        .receiveLength = sizeof(val),
+    };
+
+	res = i2csessionExecuteCommandList(&_session, &val, sizeof(val), &readRegister, sizeof(readRegister));
+	if (res)
 	{
+		i2csessionClose(&_session);
 		return res;
 	}
 
-	*out = data;
-	return res;
+	*out = val;
+	i2csessionClose(&_session);
+	return 0;
 }

--- a/include/max17050.h
+++ b/include/max17050.h
@@ -20,12 +20,15 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+/*
+ * Modified by: MasaGratoR
+ */
 
 #ifndef __MAX17050_H_
 #define __MAX17050_H_
 
 //#include <utils/types.h>
-
+#include "i2c.h"
 
 /* Board default values */
 #define MAX17050_BOARD_CGAIN 2 /* Actual: 1.99993 */
@@ -43,6 +46,9 @@
 */
 
 #define MAX17050_WAIT_NS 1175800000
+
+constexpr float max17050SenseResistor = MAX17050_BOARD_SNS_RESISTOR_UOHM / 1000; // in uOhm
+constexpr float max17050CGain = 1.99993;
 
 
 enum MAX17050_reg {
@@ -143,3 +149,17 @@ int max17050_fix_configuration();
 u32 max17050_get_cached_batt_volt();
 */
 #endif /* __MAX17050_H_ */
+
+Result Max17050ReadReg(u8 reg, u16 *out)
+{
+	u16 data = 0;
+	Result res = I2cReadRegHandler16(reg, I2cDevice_Max17050, &data);
+
+	if (R_FAILED(res))
+	{
+		return res;
+	}
+
+	*out = data;
+	return res;
+}

--- a/include/tmp451.h
+++ b/include/tmp451.h
@@ -1,0 +1,103 @@
+/*
+ * SOC/PCB Temperature driver for Nintendo Switch's TI TMP451
+ *
+ * Copyright (c) 2018 CTCaer
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Modified by: MasaGratoR
+ */
+
+#ifndef __TMP451_H_
+#define __TMP451_H_
+
+//#include <utils/types.h>
+#include "i2c.h"
+
+//#define TMP451_I2C_ADDR 0x4C
+
+#define TMP451_PCB_TEMP_REG    0x00
+#define TMP451_SOC_TEMP_REG    0x01
+
+/*
+#define TMP451_CONFIG_REG      0x09
+#define TMP451_CNV_RATE_REG    0x0A
+*/
+
+#define TMP451_SOC_TEMP_DEC_REG 0x10
+#define TMP451_PCB_TEMP_DEC_REG 0x15
+
+/*
+#define TMP451_SOC_TMP_OFH_REG 0x11
+#define TMP451_SOC_TMP_OFL_REG 0x12
+*/
+
+// If input is false, the return value is packed. MSByte is the integer in oC
+// and the LSByte is the decimal point truncated to 2 decimal places.
+// Otherwise it's an integer oC.
+/*
+u16 tmp451_get_soc_temp(bool integer);
+u16 tmp451_get_pcb_temp(bool integer);
+void tmp451_init();
+void tmp451_end();
+*/
+
+Result Tmp451ReadReg(u8 reg, u8 *out)
+{
+	u8 data = 0;
+	Result res = I2cReadRegHandler8(reg, I2cDevice_Tmp451, &data);
+
+	if (R_FAILED(res))
+	{
+		return res;
+	}
+
+	*out = data;
+	return res;
+}
+
+Result Tmp451GetSocTemp(float* temperature) {
+    u8 integer = 0;
+    u8 decimals = 0;
+
+    Result rc = Tmp451ReadReg(TMP451_SOC_TEMP_REG, &integer);
+    if (R_FAILED(rc))
+        return rc;
+    rc = Tmp451ReadReg(TMP451_SOC_TEMP_DEC_REG, &decimals);
+    if (R_FAILED(rc))
+        return rc;
+    
+    decimals = ((u16)(decimals >> 4) * 625) / 100;
+    *temperature = (float)(integer) + ((float)(decimals) / 100);
+    return rc;
+}
+
+Result Tmp451GetPcbTemp(float* temperature) {
+    u8 integer = 0;
+    u8 decimals = 0;
+
+    Result rc = Tmp451ReadReg(TMP451_PCB_TEMP_REG, &integer);
+    if (R_FAILED(rc))
+        return rc;
+    rc = Tmp451ReadReg(TMP451_PCB_TEMP_DEC_REG, &decimals);
+    if (R_FAILED(rc))
+        return rc;
+    
+    decimals = ((u16)(decimals >> 4) * 625) / 100;
+    *temperature = (float)(integer) + ((float)(decimals) / 100);
+    return rc;
+}
+
+#endif /* __TMP451_H_ */

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -224,7 +224,6 @@ public:
 			if (hosversionAtLeast(8,0,0)) clkrstCheck = clkrstInitialize();
 			else pcvCheck = pcvInitialize();
 
-			tsCheck = tsInitialize();
 			if (hosversionAtLeast(5,0,0)) tcCheck = tcInitialize();
 
 			if (hosversionAtLeast(6,0,0) && R_SUCCEEDED(pwmInitialize())) {
@@ -237,7 +236,7 @@ public:
 			if (R_SUCCEEDED(psmCheck)) {
 				psmService = psmGetServiceSession();
 			}
-			i2cInitialize();
+			i2cCheck = i2cInitialize();
 
 			SaltySD = CheckPort();
 
@@ -296,14 +295,13 @@ public:
 
 			if (R_SUCCEEDED(nvInitialize())) nvCheck = nvOpen(&fd, "/dev/nvhost-ctrl-gpu");
 
-			tsCheck = tsInitialize();
 			if (hosversionAtLeast(5,0,0)) tcCheck = tcInitialize();
 
 			if (hosversionAtLeast(6,0,0) && R_SUCCEEDED(pwmInitialize())) {
 				pwmCheck = pwmOpenSession2(&g_ICon, 0x3D000001);
 			}
 
-			i2cInitialize();
+			i2cCheck = i2cInitialize();
 
 			psmCheck = psmInitialize();
 			if (R_SUCCEEDED(psmCheck)) {

--- a/source/modes/Full.hpp
+++ b/source/modes/Full.hpp
@@ -173,10 +173,10 @@ public:
 			}
 			
 			///Thermal
-			if (R_SUCCEEDED(tsCheck) || R_SUCCEEDED(tcCheck) || R_SUCCEEDED(pwmCheck)) {
+			if (R_SUCCEEDED(i2cCheck) || R_SUCCEEDED(tcCheck) || R_SUCCEEDED(pwmCheck)) {
 				renderer->drawString("Board:", false, 20, 550, 20, renderer->a(0xFFFF));
-				if (R_SUCCEEDED(tsCheck)) renderer->drawString(BatteryDraw_c, false, COMMON_MARGIN, 575, 15, renderer->a(0xFFFF));
-				if (R_SUCCEEDED(tsCheck)) {
+				if (R_SUCCEEDED(i2cCheck)) renderer->drawString(BatteryDraw_c, false, COMMON_MARGIN, 575, 15, renderer->a(0xFFFF));
+				if (R_SUCCEEDED(i2cCheck) || R_SUCCEEDED(tcCheck)) {
 					auto dimensions1 = renderer->drawString("Temperatures: ", false, 0, 590, 15, renderer->a(0x0000));
 					auto dimensions2 = renderer->drawString("SoC \nPCB \nSkin ", false, 0, 590, 15, renderer->a(0x0000));
 					renderer->drawString("Temperatures:", false, COMMON_MARGIN, 590, 15, renderer->a(0xFFFF));
@@ -288,18 +288,9 @@ public:
 				RAM_GPU_Load / 10, RAM_GPU_Load % 10);
 		}
 		///Thermal
-		if (hosversionAtLeast(10,0,0)) {
-			snprintf(SoCPCB_temperature_c, sizeof SoCPCB_temperature_c, 
-				"%2.1f\u00B0C\n%2.1f\u00B0C\n%2d.%d\u00B0C", 
-				SOC_temperatureF, PCB_temperatureF, skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
-		}
-		else {
-			snprintf(SoCPCB_temperature_c, sizeof SoCPCB_temperature_c, 
-				"%2d.%d\u00B0C\n%2d.%d\u00B0C\n%2d.%d\u00B0C", 
-				SOC_temperatureC / 1000, (SOC_temperatureC / 100) % 10, 
-				PCB_temperatureC / 1000, (PCB_temperatureC % 100) % 10,
-				skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
-		}
+		snprintf(SoCPCB_temperature_c, sizeof SoCPCB_temperature_c, 
+			"%2.1f\u00B0C\n%2.1f\u00B0C\n%2d.%d\u00B0C", 
+			SOC_temperatureF, PCB_temperatureF, skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
 		snprintf(Rotation_SpeedLevel_c, sizeof Rotation_SpeedLevel_c, "Fan Rotation Level: %2.1f%%", Rotation_Duty);
 		
 		///FPS

--- a/source/modes/Micro.hpp
+++ b/source/modes/Micro.hpp
@@ -330,21 +330,11 @@ public:
 		else snprintf(remainingBatteryLife, sizeof remainingBatteryLife, "-:--");
 
 		///Thermal
-		if (hosversionAtLeast(10,0,0)) {
-			snprintf(skin_temperature_c, sizeof skin_temperature_c, 
-				"%2.1f/%2.1f/%hu.%hhu\u00B0C@%+.1fW[%s]", 
-				SOC_temperatureF, PCB_temperatureF, 
-				skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10, 
-				PowerConsumption, remainingBatteryLife);
-		}
-		else {
-			snprintf(skin_temperature_c, sizeof skin_temperature_c, 
-				"%hu.%hhu/%hu.%hhu/%hu.%hhu\u00B0C@%+.1fW[%s]", 
-				SOC_temperatureC / 1000, (SOC_temperatureC / 100) % 10, 
-				PCB_temperatureC / 1000, (PCB_temperatureC / 100) % 10, 
-				skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10, 
-				PowerConsumption, remainingBatteryLife);
-		}
+		snprintf(skin_temperature_c, sizeof skin_temperature_c, 
+			"%2.1f/%2.1f/%hu.%hhu\u00B0C@%+.1fW[%s]", 
+			SOC_temperatureF, PCB_temperatureF, 
+			skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10, 
+			PowerConsumption, remainingBatteryLife);
 		mutexUnlock(&mutex_BatteryChecker);
 		snprintf(Rotation_SpeedLevel_c, sizeof Rotation_SpeedLevel_c, "%2.1f%%", Rotation_Duty);
 		

--- a/source/modes/Mini.hpp
+++ b/source/modes/Mini.hpp
@@ -323,19 +323,10 @@ public:
 		}
 		
 		///Thermal
-		if (hosversionAtLeast(10,0,0)) {
-			snprintf(skin_temperature_c, sizeof skin_temperature_c, 
-				"%2.1f\u00B0C/%2.1f\u00B0C/%hu.%hhu\u00B0C", 
-				SOC_temperatureF, PCB_temperatureF, 
-				skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
-		}
-		else {
-			snprintf(skin_temperature_c, sizeof skin_temperature_c, 
-				"%hu.%hhu\u00B0C/%hu.%hhu\u00B0C/%hu.%hhu\u00B0C", 
-				SOC_temperatureC / 1000, (SOC_temperatureC / 100) % 10, 
-				PCB_temperatureC / 1000, (PCB_temperatureC / 100) % 10, 
-				skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
-		}
+		snprintf(skin_temperature_c, sizeof skin_temperature_c, 
+			"%2.1f\u00B0C/%2.1f\u00B0C/%hu.%hhu\u00B0C", 
+			SOC_temperatureF, PCB_temperatureF, 
+			skin_temperaturemiliC / 1000, (skin_temperaturemiliC / 100) % 10);
 		snprintf(Rotation_SpeedLevel_c, sizeof Rotation_SpeedLevel_c, "%2.1f%%", Rotation_Duty);
 
 		if (GameRunning && renderCalls_shared && resolutionShow) {


### PR DESCRIPTION
Fixing potential issue with sleep mode at 19.0.0+ that was found in sys-clk