### PR TITLE
Fix [mini] config parsing

### DIFF
--- a/source/Utils.hpp
+++ b/source/Utils.hpp
@@ -1087,7 +1087,7 @@ ALWAYS_INLINE void GetConfigSettings(MiniSettings* settings) {
 		if (convertStrToRGBA4444(key, &temp))
 			settings -> textColor = temp;
 	}
-	if (parsedData["mini"].find("show") != parsedData["micro"].end()) {
+	if (parsedData["mini"].find("show") != parsedData["mini"].end()) {
 		key = parsedData["mini"]["show"];
 		convertToUpper(key);
 		settings -> show = key;


### PR DESCRIPTION
Hey, thanks for a great tool.
I found a small issue in the config parser.

## How to reproduce

With this config file the **Mini** mode does not show anything:

```ini
[mini]
handheld_font_size=20
docked_font_size=20
cat_color=#FCCF
```

(no other entries in the file, just these 4 lines)

## Fix

I think it's just a typo in the `[mini]` parsing block.
With this fix, all modes show up correctly for me.